### PR TITLE
Follow up of new cops (v0.59.0)

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -130,6 +130,8 @@ Layout/EmptyLines:
   Enabled: false
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 Layout/EmptyLinesAroundBeginBody:


### PR DESCRIPTION
See also https://github.com/rubocop-hq/rubocop/releases/tag/v0.59.0

There are no new cops in v0.59.0, but enabled `Layout/EmptyLineAfterGuardClause` cop by default from this version. Since this cop focuses on the style, I judged that it should be disabled in MeowCop.