### PR TITLE
Follow up of new cops (v0.60 ~ v0.64)

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -96,6 +96,8 @@ Rails/RefuteMethods:
   Enabled: false
 Rails/AssertNot:
   Enabled: false
+Rails/ReflectionClassName:
+  Enabled: false
 
 Security/Eval:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '>= 0.57.0'
+  spec.add_dependency 'rubocop', '>= 0.64.0'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
## v0.60
https://github.com/rubocop-hq/rubocop/releases/tag/v0.60.0

- No new cops

## v0.61
https://github.com/rubocop-hq/rubocop/releases/tag/v0.61.0

- New cop Performance/OpenStruct checks for OpenStruct.new calls.
  - https://github.com/rubocop-hq/rubocop/pull/6486
  - Diabled by default

## v0.62
https://github.com/rubocop-hq/rubocop/releases/tag/v0.62.0

- New cop Rails/LinkToBlank checks for link_to calls with target: '_blank' and no rel: 'noopener'.
  - https://github.com/rubocop-hq/rubocop/pull/6580
  - In my opinion, this cop helps us to find security risks. I guess we should enable it.

## v0.63
https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.0

- Add new Rails/IgnoredSkipActionFilterOption cop.
  - https://github.com/rubocop-hq/rubocop/pull/6660
  - This cop exactly find bugs :upside_down_face: 
- Add new Rails/BelongsTo cop with auto-correct for Rails >= 5.
  - https://github.com/rubocop-hq/rubocop/pull/6596
  - I think that it is important to constantly fix deprecations. Especially it is so on the Rails.
- Move FlipFlop cop from Style to Lint department because flip-flop is deprecated since Ruby 2.6.0.
  - https://github.com/rubocop-hq/rubocop/pull/6636
  - Exactly. `Style/FlipFlop` is already enabled by default in MeowCop.

## v0.64
https://github.com/rubocop-hq/rubocop/releases/tag/v0.64.0

- Add new Rails/ReflectionClassName cop.
  - https://github.com/rubocop-hq/rubocop/pull/6704
  - I'm wondering if this cop should be enabled or not :thinking: Certainly, string as `class_name` option is deprecated. This Cop certainly brings good results, but I'm not sure whether to turn on in MeowCop. I temporarily disable it.