### PR TITLE
Follow up of new cops (v0.67)

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -68,6 +68,8 @@ Metrics/PerceivedComplexity:
 Performance/RedundantBlockCall:
   Enabled: false
 
+Rails/ActiveRecordOverride:
+  Enabled: false
 Rails/ActiveSupportAliases:
   Enabled: false
 Rails/Delegate:
@@ -262,6 +264,8 @@ Naming/HeredocDelimiterNaming:
 Naming/MethodName:
   Enabled: false
 Naming/PredicateName:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
   Enabled: false
 Naming/VariableName:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '>= 0.57.0'
+  spec.add_dependency 'rubocop', '>= 0.67.0'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Fixes #39 

https://github.com/rubocop-hq/rubocop/releases/tag/v0.67.0

- Add new multiline element line break cops.
  - https://github.com/rubocop-hq/rubocop/pull/6824
  - `Layout/MultilineArrayLineBreaks`, `Layout/MultilineHashKeyLineBreaks` and `Layout/MultilineMethodArgumentLineBreaks` forces on style issues, but these are disabled by default.
- Add new cop Rails/ActiveRecordOverride that checks for overriding Active Record methods instead of using callbacks.
  - https://github.com/rubocop-hq/rubocop/pull/6853
  - IMO, this is a style issue.
- Add new cop Rails/RedundantAllowNil that checks for cases when allow_blank makes allow_nil unnecessary in model validations.
  - https://github.com/rubocop-hq/rubocop/pull/6848
  - This Cop can warn of unintended validation behavior. I decided that it should be enabled.
- Add new Naming/RescuedExceptionsVariableName cop.
  - https://github.com/rubocop-hq/rubocop/commit/f0959e8eda5b8f45956cd127fd18389a5a9594c8
  - This is a naming convention.
- Move LstripRstrip from Performance to Style department and rename it to Strip. 
  - https://github.com/rubocop-hq/rubocop/pull/6870
  - `Style/Strip` forces a style issue, but `strip` is better than `rstrip.lstrip` clearly.
- Move Performance/RedundantSortBy, Performance/UnneededSort and Performance/Sample to the Style department.
  - https://github.com/rubocop-hq/rubocop/commit/32ed7d197855b66e16f1ef1a7ecdc409112ead14
  - These cops also forces on style issues, but these are generally good styles.