### PR TITLE
RuboCop v0.68

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -65,9 +65,6 @@ Metrics/PerceivedComplexity:
   Enabled: true
 # Use the default setting
 
-Performance/RedundantBlockCall:
-  Enabled: false
-
 Rails/ActiveRecordOverride:
   Enabled: false
 Rails/ActiveSupportAliases:
@@ -107,6 +104,8 @@ Security/YAMLLoad:
   Enabled: false
 
 Layout/AccessModifierIndentation:
+  Enabled: false
+Layout/AlignArguments:
   Enabled: false
 Layout/AlignArray:
   Enabled: false
@@ -152,9 +151,13 @@ Layout/EndOfLine:
   Enabled: false
 Layout/ExtraSpacing:
   Enabled: false
+Layout/HeredocArgumentClosingParenthesis:
+  Enabled: false
 Layout/IndentFirstArgument:
   Enabled: false
 Layout/IndentFirstArrayElement:
+  Enabled: false
+Layout/IndentFirstParameter:
   Enabled: false
 Layout/IndentAssignment:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '>= 0.67.0'
+  spec.add_dependency 'rubocop', '>= 0.68.0'
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
See also https://github.com/sider/meowcop/pull/41

- `Layout/AlignArguments`
- `Layout/HeredocArgumentClosingParenthesis`
- `Layout/IndentFirstParameter`
  - These cops also focused on styles(layouts).
- `Performance/RedundantBlockCall`
  - Performance cops are extracted as `rubocop-performance`. See https://github.com/rubocop-hq/rubocop/issues/5977
- `Lint/HeredocMethodCallPosition`
  - Certainly, it focuses on styles, but it also suggests avoiding possible errors. This is a difficult problem, but I decided to enable it here. See https://github.com/rubocop-hq/rubocop/pull/6989