### PR TITLE
Follow up of RuboCop v0.72

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ inherit_gem:
 # Modify the version if you don't use MRI 2.6.
 AllCops:
   TargetRubyVersion: 2.6
-  # If you use RuboCop with Ruby on Rails, specify TargetRailsVersion(default: 5.0).
-  TargetRailsVersion: 5.0
-
-Rails:
-  # If you use RuboCop with Ruby on Rails, turn on this option.
-  Enabled: false
 
 # You can customize rubocop settings.
 # For example.

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -63,38 +63,6 @@ Metrics/ParameterLists:
 # Use the default setting
 Metrics/PerceivedComplexity:
   Enabled: true
-# Use the default setting
-
-Rails/ActiveRecordOverride:
-  Enabled: false
-Rails/ActiveSupportAliases:
-  Enabled: false
-Rails/Delegate:
-  Enabled: false
-Rails/FilePath:
-  Enabled: false
-Rails/HttpPositionalArguments:
-  Enabled: false
-Rails/Output:
-  Enabled: false
-Rails/OutputSafety:
-  Enabled: false
-Rails/PluralizationGrammar:
-  Enabled: false
-Rails/SkipsModelValidations:
-  Enabled: false
-Rails/ReadWriteAttribute:
-  Enabled: false
-Rails/RequestReferer:
-  Enabled: false
-Rails/SafeNavigation:
-  Enabled: false
-Rails/HttpStatus:
-  Enabled: false
-Rails/RefuteMethods:
-  Enabled: false
-Rails/AssertNot:
-  Enabled: false
 
 Security/Eval:
   Enabled: false
@@ -338,6 +306,8 @@ Style/Encoding:
 Style/EndBlock:
   Enabled: false
 Style/EvenOdd:
+  Enabled: false
+Style/FloatDivision:
   Enabled: false
 Style/For:
   Enabled: false

--- a/examples/.rubocop.yml
+++ b/examples/.rubocop.yml
@@ -6,12 +6,6 @@ inherit_gem:
 # Modify the version if you don't use MRI 2.6.
 AllCops:
   TargetRubyVersion: 2.6
-  # If you use RuboCop with Ruby on Rails, specify TargetRailsVersion(default: 5.0).
-  TargetRailsVersion: 5.0
-
-Rails:
-  # If you use RuboCop with Ruby on Rails, turn on this option.
-  Enabled: false
 
 # You can customize rubocop settings.
 # For example.

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '>= 0.69.0'
+  spec.add_dependency 'rubocop', '>= 0.72.0'
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Fixes #49 
See https://github.com/rubocop-hq/rubocop/releases/tag/v0.72.0

## New cops

- `Gemspec/RubyVersionGlobalsUsage`
  - :+1: It focused on linting.
- `Style/FloatDivision`
  - This is a style issue. Disabled.

## Changes

- Remove Rails cops
  - We also remove Rails cops configuration from the gem.