### PR TITLE
Ignore `vendor/bundle` directory on Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/bundle/
 /.yardoc
 /Gemfile.lock
 /_yardoc/


### PR DESCRIPTION
> `bundle install --deployment` installs gems to the `vendor/bundle` directory in the application.

https://bundler.io/man/bundle-install.1.html#DEPLOYMENT-MODE