### PR TITLE
Add license and update gemspec

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Masataka Kuwabara and Sider, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -6,12 +6,19 @@ require 'meowcop/version'
 Gem::Specification.new do |spec|
   spec.name          = "meowcop"
   spec.version       = Meowcop::VERSION
-  spec.authors       = ["Masataka Kuwabara"]
-  spec.email         = ["p.ck.t22@gmail.com"]
+  spec.licenses      = ["MIT"]
+  spec.authors       = ["Masataka Kuwabara", "Sider, Inc."]
+  spec.email         = "support@sider.review"
 
-  spec.summary       = %q{MeowCop is a RuboCop configuration recommended by Sider, Inc.}
+  spec.summary       = %q{A RuboCop configuration focusing Lint}
   spec.description   = %q{MeowCop is a RuboCop configuration recommended by Sider, Inc.}
   spec.homepage      = "https://github.com/sider/meowcop"
+
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/sider/meowcop/issues",
+    "changelog_uri" => "https://github.com/sider/meowcop/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/sider/meowcop"
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
- Add missing OSS license: MIT
- Update gemspec (authors, email, metadata, etc.)