### PR TITLE
Follow up of RuboCop v0.74 and v0.75

### DIFF
--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '>= 0.73.0'
+  spec.add_dependency "rubocop", ">= 0.75.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.75.0
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.74.0

No new cops.