### PR TITLE
Set `>= 2.3.0` to `required_ruby_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#69](https://github.com/sider/meowcop/pull/69): Lighten the archived gem size
+- [#74](https://github.com/sider/meowcop/pull/74): Set `>= 2.3.0` to `required_ruby_version`
 
 ## 2.3.1 (2019-10-01)
 

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_dependency "rubocop", ">= 0.75.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"


### PR DESCRIPTION
Following RuboCop master:

https://github.com/rubocop-hq/rubocop/blob/f50749723726c31c3ac52402632a2907505feea1/rubocop.gemspec#L11