### PR TITLE
Follow up of RuboCop v0.76 (including breaking changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#80](https://github.com/sider/meowcop/pull/80): Follow up of RuboCop v0.76 (including breaking changes)
+
 ## 2.4.0 (2019-10-08)
 
 - [#69](https://github.com/sider/meowcop/pull/69): Lighten the archived gem size

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -29,7 +29,7 @@ Lint/Loop:
   Enabled: false
 Lint/RescueException:
   Enabled: false
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: false
 Lint/UnusedBlockArgument:
   Enabled: false
@@ -484,17 +484,27 @@ Style/RandomWithOffset:
   Enabled: false
 Style/RedundantBegin:
   Enabled: false
+Style/RedundantCapitalW:
+  Enabled: false
+Style/RedundantCondition:
+  Enabled: false
 Style/RedundantConditional:
   Enabled: false
 Style/RedundantException:
   Enabled: false
 Style/RedundantFreeze:
   Enabled: false
+Style/RedundantInterpolation:
+  Enabled: false
 Style/RedundantParentheses:
+  Enabled: false
+Style/RedundantPercentQ:
   Enabled: false
 Style/RedundantReturn:
   Enabled: false
 Style/RedundantSelf:
+  Enabled: false
+Style/RedundantSort:
   Enabled: false
 Style/RedundantSortBy:
   Enabled: false
@@ -565,16 +575,6 @@ Style/TrailingUnderscoreVariable:
 Style/TrivialAccessors:
   Enabled: false
 Style/UnlessElse:
-  Enabled: false
-Style/UnneededCapitalW:
-  Enabled: false
-Style/UnneededCondition:
-  Enabled: false
-Style/UnneededInterpolation:
-  Enabled: false
-Style/UnneededPercentQ:
-  Enabled: false
-Style/UnneededSort:
   Enabled: false
 Style/UnpackFirst:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "rubocop", ">= 0.75.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.76.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.76.0
- https://github.com/rubocop-hq/rubocop/blob/v0.76.0/CHANGELOG.md
- (Breaking) Rename `Unneeded*` cops to `Redundant*`.