### PR TITLE
Change the gem's author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#82](https://github.com/sider/meowcop/pull/82): Change the gem's author
+
 ## 2.5.0 (2019-10-29)
 
 - [#80](https://github.com/sider/meowcop/pull/80): Follow up of RuboCop v0.76 (including breaking changes)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Masataka Kuwabara and Sider, Inc.
+Copyright (c) 2016 Sleeek Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "meowcop"
   spec.version       = Meowcop::VERSION
   spec.licenses      = ["MIT"]
-  spec.authors       = ["Masataka Kuwabara", "Sider, Inc."]
+  spec.authors       = ["Sleeek Corporation"]
   spec.email         = "support@sider.review"
 
   spec.summary       = %q{A RuboCop configuration focusing Lint}


### PR DESCRIPTION
[Sleeek Corporation](https://www.sleeek.io/) owns Sider now.
See our [blog post](https://blog.sideci.com/siders-operating-company-will-change-to-sleeek-co-ltd-on-october-31-2019-a86c37fc7a4f) for details.