### PR TITLE
Follow up RuboCop v0.77 (including breaking changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#82](https://github.com/sider/meowcop/pull/82): Change the gem's author
+- [#83](https://github.com/sider/meowcop/pull/83): Follow up RuboCop v0.77 (including breaking changes)
 
 ## 2.5.0 (2019-10-29)
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -23,7 +23,7 @@ Lint/AssignmentInCondition:
 # See. http://tech.sideci.com/entry/2016/11/01/105900
 Lint/EmptyWhen:
   Enabled: false
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 Lint/Loop:
   Enabled: false
@@ -78,13 +78,13 @@ Security/YAMLLoad:
 
 Layout/AccessModifierIndentation:
   Enabled: false
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: false
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: false
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 Layout/BlockEndNewline:
   Enabled: false
@@ -126,21 +126,21 @@ Layout/ExtraSpacing:
   Enabled: false
 Layout/HeredocArgumentClosingParenthesis:
   Enabled: false
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: false
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: false
-Layout/IndentFirstParameter:
+Layout/FirstParameterIndentation:
   Enabled: false
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Enabled: false
 Layout/IndentationConsistency:
   Enabled: false
 Layout/IndentationWidth:
   Enabled: false
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Layout/InitialIndentation:
   Enabled: false
@@ -212,7 +212,7 @@ Layout/SpaceInsideReferenceBrackets:
   Enabled: false
 Layout/SpaceInsideStringInterpolation:
   Enabled: false
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 Layout/TrailingWhitespace:
   Enabled: false
@@ -224,7 +224,7 @@ Layout/EndAlignment:
   Enabled: false
 Layout/ClosingHeredocIndentation:
   Enabled: false
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: false
 
 Naming/AccessorMethodName:
@@ -247,9 +247,9 @@ Naming/VariableName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
-Naming/UncommunicativeBlockParamName:
+Naming/BlockParameterName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 # THIS BLOCK IS AUTO-GENERATED. DO NOT EDIT.

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "rubocop", ">= 0.76.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.77.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.77.0
- https://github.com/rubocop-hq/rubocop/blob/v0.77.0/CHANGELOG.md

This includes breaking changes since RuboCop v0.77.0.
The changes is renaming some cops for consistency.
See rubocop-hq/rubocop#7077 for details.