### PR TITLE
Follow up RuboCop v0.78 (breaking)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.3", "2.4", "2.5", "2.6"]
+        ruby: ["2.4", "2.5", "2.6"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#84](https://github.com/sider/meowcop/pull/84) Follow up RuboCop v0.78 (breaking)
+
 ## 2.6.0 (2019-11-28)
 
 - [#82](https://github.com/sider/meowcop/pull/82): Change the gem's author

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -55,8 +55,6 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Max: 10
-Metrics/LineLength:
-  Max: 200
 Metrics/MethodLength:
   Enabled: false
 Metrics/ModuleLength:
@@ -146,6 +144,8 @@ Layout/InitialIndentation:
   Enabled: false
 Layout/LeadingCommentSpace:
   Enabled: false
+Layout/LineLength:
+  Max: 200
 Layout/MultilineArrayBraceLayout:
   Enabled: false
 Layout/MultilineAssignmentLayout:

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "rubocop", ">= 0.77.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.78.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/test/smoke/Dockerfile
+++ b/test/smoke/Dockerfile
@@ -18,4 +18,5 @@ RUN rake install && \
     echo '  Enabled: true' >> .rubocop.yml && \
     cat .rubocop.yml
 
-ENTRYPOINT test "$(rubocop test/smoke --format=simple)" = "$(cat test/smoke/expectation-output.txt)"
+ENTRYPOINT meowcop run test/meowcop && \
+           test "$(rubocop test/smoke --format=simple)" = "$(cat test/smoke/expectation-output.txt)"


### PR DESCRIPTION
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.78.0
- https://github.com/rubocop-hq/rubocop/pull/7542 (breaking)

Here is the breaking error message:

> Metrics/LineLength has the wrong namespace - should be Layout