### PR TITLE
Follow up RuboCop v0.80 (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- [#89](https://github.com/sider/meowcop/pull/89): Follow up RuboCop v0.80 (breaking)
+
 ## 2.7.0 (2019-12-19)
 
-- [#84](https://github.com/sider/meowcop/pull/84) Follow up RuboCop v0.78 (breaking)
+- [#84](https://github.com/sider/meowcop/pull/84): Follow up RuboCop v0.78 (breaking)
 
 ## 2.6.0 (2019-11-28)
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -276,8 +276,6 @@ Style/BlockComments:
   Enabled: false
 Style/BlockDelimiters:
   Enabled: false
-Style/BracesAroundHashParameters:
-  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/CharacterLiteral:
@@ -362,7 +360,13 @@ Style/GlobalVars:
   Enabled: false
 Style/GuardClause:
   Enabled: false
+Style/HashEachMethods:
+  Enabled: false
 Style/HashSyntax:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
   Enabled: false
 Style/IdenticalConditionalBranches:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "rubocop", ">= 0.78.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.80.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Release note: <https://github.com/rubocop-hq/rubocop/releases/tag/v0.80.0>

- (breaking) Remove `Style/BracesAroundHashParameters` cop. See <https://github.com/rubocop-hq/rubocop/issues/7641>.
- Disable some new `Style` cops.