### PR TITLE
Update CI configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,6 @@
 name: Test
 
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   test:
@@ -16,10 +10,11 @@ jobs:
         ruby: [2.3, 2.4, 2.5, 2.6, 2.7]
     steps:
       - uses: actions/checkout@v2
-      - uses: eregon/use-ruby-action@master
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: gem update --system --no-document
       - run: gem install bundler --no-document
-      - run: bundle install --jobs=4 --retry=3 --path=vendor/bundle
+      - run: bundle config set path vendor/bundle
+      - run: bundle install --jobs=4 --retry=3
       - run: bundle exec rake


### PR DESCRIPTION
- Simplify `on:` setting.
- Use [ruby/setup-ruby](https://github.com/ruby/setup-ruby) instead of [eregon/use-ruby-action](https://github.com/eregon/use-ruby-action)
- Use `bundle config set` instead of `bundle install --path` option.
  See <https://github.com/rubygems/bundler/blob/master/UPGRADING.md#cli-deprecations>