### PR TITLE
Fix company name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/meowcop.svg)](https://badge.fury.io/rb/meowcop)
 
 MeowCop is a gem for shareable [RuboCop](https://www.rubocop.org) configuration, it focuses [Lint](https://en.wikipedia.org/wiki/Lint_(software)).
-It's recommended by Sider, Inc.
+It's recommended by Sider.
 
 ## Design
 

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = "support@sider.review"
 
   spec.summary       = %q{A RuboCop configuration focusing Lint}
-  spec.description   = %q{MeowCop is a RuboCop configuration recommended by Sider, Inc.}
+  spec.description   = %q{MeowCop is a RuboCop configuration recommended by Sider.}
   spec.homepage      = "https://github.com/sider/meowcop"
 
   spec.metadata = {


### PR DESCRIPTION
Sider, Inc. does not exist, so this renames it from the company name to the service name.