### PR TITLE
Follow up RuboCop v0.82 (breaking)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: push
+on:
+  push:
+    tags: ["**"]
 
 jobs:
   build:
@@ -8,7 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           body: |
             See the [changelog](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/CHANGELOG.md) for more details.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- [#92](https://github.com/sider/meowcop/pull/92): Follow up RuboCop v0.82 (breaking)
+
+### Breaking Change
+
+RuboCop 0.82 has dropped the support for Ruby 2.3. It requires Ruby 2.4+.
+
 ## 2.8.0 (2020-02-19)
 
 - [#89](https://github.com/sider/meowcop/pull/89): Follow up RuboCop v0.80 (breaking)

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -312,6 +312,8 @@ Style/DefWithParentheses:
   Enabled: false
 Style/Dir:
   Enabled: false
+Style/DisableCopsWithinSourceCodeDirective:
+  Enabled: false
 Style/Documentation:
   Enabled: false
 Style/DocumentationMethod:
@@ -345,6 +347,8 @@ Style/EvalWithLocation:
 Style/EvenOdd:
   Enabled: false
 Style/ExpandPathArguments:
+  Enabled: false
+Style/ExponentialNotation:
   Enabled: false
 Style/FloatDivision:
   Enabled: false
@@ -569,6 +573,8 @@ Style/TrailingBodyOnModule:
 Style/TrailingCommaInArguments:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInBlockArgs:
   Enabled: false
 Style/TrailingCommaInHashLiteral:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "rubocop", ">= 0.80.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.82.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.12", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
See <https://github.com/rubocop-hq/rubocop/releases/tag/v0.82.0>

RuboCop 0.82 has dropped the support for Ruby 2.3. It requires Ruby 2.4+.