### PR TITLE
Follow up RuboCop v0.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#97](https://github.com/sider/meowcop/pull/97): Follow up RuboCop v0.86
+
 ## 2.9.0 (2020-04-17)
 
 - [#92](https://github.com/sider/meowcop/pull/92): Follow up RuboCop v0.82 (breaking)

--- a/Rakefile
+++ b/Rakefile
@@ -16,12 +16,8 @@ end
 
 desc "Run smoke tests"
 task :smoke do
-  sh "docker build -t meowcop/smoke -f test/smoke/Dockerfile ."
-  sh "docker run --rm meowcop/smoke" do |ok|
-    unless ok
-      sh "docker run --rm --entrypoint=rubocop meowcop/smoke test/smoke --format=simple"
-    end
-  end
+  sh "docker", "build", "-t", "meowcop/smoke", "-f", "test/smoke/Dockerfile", "."
+  sh "docker", "run", "--rm", "meowcop/smoke"
 end
 
 namespace :config do

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -106,6 +106,8 @@ Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
 Layout/EmptyLinesAroundBeginBody:
   Enabled: false
 Layout/EmptyLinesAroundBlockBody:
@@ -179,6 +181,8 @@ Layout/SpaceAroundBlockParameters:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 Layout/SpaceAroundKeyword:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
   Enabled: false
 Layout/SpaceAroundOperators:
   Enabled: false
@@ -500,6 +504,8 @@ Style/RedundantConditional:
   Enabled: false
 Style/RedundantException:
   Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
 Style/RedundantFreeze:
   Enabled: false
 Style/RedundantInterpolation:
@@ -507,6 +513,10 @@ Style/RedundantInterpolation:
 Style/RedundantParentheses:
   Enabled: false
 Style/RedundantPercentQ:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
   Enabled: false
 Style/RedundantReturn:
   Enabled: false
@@ -539,6 +549,8 @@ Style/SignalException:
 Style/SingleLineBlockParams:
   Enabled: false
 Style/SingleLineMethods:
+  Enabled: false
+Style/SlicingWithRange:
   Enabled: false
 Style/SpecialGlobalVars:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "rubocop", ">= 0.82.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.86.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 2.1"
   spec.add_development_dependency "rake", ">= 13.0"

--- a/test/smoke/Dockerfile
+++ b/test/smoke/Dockerfile
@@ -18,5 +18,5 @@ RUN rake install && \
     echo '  Enabled: true' >> .rubocop.yml && \
     cat .rubocop.yml
 
-ENTRYPOINT meowcop run test/meowcop && \
-           test "$(rubocop test/smoke --format=simple)" = "$(cat test/smoke/expectation-output.txt)"
+ENTRYPOINT test "$(rubocop test/smoke --format=simple 2>&1)" = "$(cat test/smoke/expectation-output.txt)" && \
+           test "$(meowcop run test/smoke --format=simple 2>&1)" = "$(cat test/smoke/expectation-output2.txt)"

--- a/test/smoke/expectation-output.txt
+++ b/test/smoke/expectation-output.txt
@@ -1,3 +1,9 @@
+The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
+ - Lint/DeprecatedOpenSSLConstant (0.84)
+ - Lint/MixedRegexpCaptureTypes (0.85)
+ - Lint/RaiseException (0.81)
+ - Lint/StructNewOverride (0.81)
+For more information: https://docs.rubocop.org/rubocop/versioning.html
 == test/smoke/test.rb ==
 C:  5: 10: Style/StringHashKeys: Prefer symbols instead of strings as hash keys. (https://rubystyle.guide#symbols-as-keys)
 C:  7:  1: Style/ZeroLengthPredicate: Use empty? instead of length == 0.

--- a/test/smoke/expectation-output2.txt
+++ b/test/smoke/expectation-output2.txt
@@ -1,0 +1,4 @@
+== test/smoke/test.rb ==
+C:  5: 10: Style/StringHashKeys: Prefer symbols instead of strings as hash keys. (https://rubystyle.guide#symbols-as-keys)
+
+1 file inspected, 1 offense detected


### PR DESCRIPTION
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.86.0
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.85.0
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.84.0
- https://github.com/rubocop-hq/rubocop/releases/tag/v0.83.0