### PR TITLE
Empower CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#97](https://github.com/sider/meowcop/pull/97): Follow up RuboCop v0.86
+- [#98](https://github.com/sider/meowcop/pull/98): Empower CLI
 
 ## 2.9.0 (2020-04-17)
 

--- a/lib/meowcop.rb
+++ b/lib/meowcop.rb
@@ -1,6 +1,9 @@
 require "meowcop/version"
 require 'meowcop/cli'
 
-module Meowcop
+module MeowCop
   # Your code goes here...
 end
+
+# Ensure backward compatibility
+Meowcop = MeowCop

--- a/lib/meowcop/version.rb
+++ b/lib/meowcop/version.rb
@@ -1,3 +1,3 @@
-module Meowcop
+module MeowCop
   VERSION = "2.9.0".freeze
 end

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -5,7 +5,7 @@ require 'meowcop/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "meowcop"
-  spec.version       = Meowcop::VERSION
+  spec.version       = MeowCop::VERSION
   spec.licenses      = ["MIT"]
   spec.authors       = ["Sleeek Corporation"]
   spec.email         = "support@sider.review"

--- a/test/meowcop/cli_test.rb
+++ b/test/meowcop/cli_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 require "rubocop"
 
 class CLITest < Minitest::Test
+  CLI = MeowCop::CLI
+
   def setup
     @origdir = Dir.pwd
     @workdir = Dir.mktmpdir
     Dir.chdir @workdir
-
-    @cli = Meowcop::CLI.new
   end
 
   def teardown
@@ -16,21 +16,21 @@ class CLITest < Minitest::Test
   end
 
   def test_start_when_invalid_command
-    assert_output(/Could not find command foo./) do
-      assert_equal 0, Meowcop::CLI.start(["foo"])
+    assert_output(/Could not find command 'foo'./) do
+      assert_equal 1, CLI.start(["foo"])
     end
   end
 
   def test_init_when_created
     assert_output("Meow! .rubocop.yml has been created successfully.\n") do
-      assert_equal 0, @cli.init([])
+      assert_equal 0, CLI.start(["init"])
     end
   end
 
   def test_init_when_updated
     FileUtils.touch ".rubocop.yml"
     assert_output("Meow! .rubocop.yml has been overwritten successfully.\n") do
-      assert_equal 0, @cli.init([])
+      assert_equal 0, CLI.start(["init"])
     end
   end
 
@@ -39,13 +39,22 @@ class CLITest < Minitest::Test
     rubocop_cli.expect :run, 0, [["--config", Pathname(@origdir).join("examples/.rubocop.yml").to_s, "--foo", "bar"]]
 
     RuboCop::CLI.stub :new, rubocop_cli do
-      assert_equal 0, @cli.run(["--foo", "bar"])
+      assert_equal 0, CLI.start(["run", "--foo", "bar"])
+      assert_mock rubocop_cli
     end
   end
 
   def test_help
-    assert_output(/MeowCop commands:/) do
-      assert_equal 0, @cli.help([])
+    expected = /\AUsage: meowcop <command>\n/
+    assert_output(expected) do
+      assert_equal 0, CLI.start(["help"])
+    end
+  end
+
+  def test_version
+    expected = "2.9.0\n"
+    assert_output(expected) do
+      assert_equal 0, CLI.start(["version"])
     end
   end
 end


### PR DESCRIPTION
- Add a `version` sub-command to show this gem version.
- Exit with `1` when the sub-command is invalid.
- Add a `MeowCop` alias to the `Meowcop` module.