### PR TITLE
Fix `CLITest#test_version` due to version-up

### DIFF
--- a/test/meowcop/cli_test.rb
+++ b/test/meowcop/cli_test.rb
@@ -52,7 +52,7 @@ class CLITest < Minitest::Test
   end
 
   def test_version
-    expected = "2.9.0\n"
+    expected = "#{MeowCop::VERSION}\n"
     assert_output(expected) do
       assert_equal 0, CLI.start(["version"])
     end


### PR DESCRIPTION
```
test_version#CLITest (0.10s)
  In stdout.
  --- expected
  +++ actual
  @@ -1,2 +1,2 @@
  -"2.9.0
  +"2.10.0
   "
  /home/runner/work/meowcop/meowcop/test/meowcop/cli_test.rb:56:in `test_version'
```