### PR TITLE
Follow up RuboCop v0.87

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: ./config/rubocop.yml
 
+AllCops:
+  NewCops: enable
+
 Style/StringHashKeys:
   Exclude:
     - "test/smoke/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#100](https://github.com/sider/meowcop/pull/100): Follow up RuboCop v0.87
+
 ## 2.10.0 (2020-07-01)
 
 - [#97](https://github.com/sider/meowcop/pull/97): Follow up RuboCop v0.86

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -260,6 +260,8 @@ Naming/MethodParameterName:
 # === Disabled cops: BEGIN ===
 Style/AccessModifierDeclarations:
   Enabled: false
+Style/AccessorGrouping:
+  Enabled: false
 Style/Alias:
   Enabled: false
 Style/AndOr:
@@ -275,6 +277,8 @@ Style/AutoResourceCleanup:
 Style/BarePercentLiterals:
   Enabled: false
 Style/BeginBlock:
+  Enabled: false
+Style/BisectedAttrAccessor:
   Enabled: false
 Style/BlockComments:
   Enabled: false
@@ -494,6 +498,8 @@ Style/RaiseArgs:
   Enabled: false
 Style/RandomWithOffset:
   Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
 Style/RedundantBegin:
   Enabled: false
 Style/RedundantCapitalW:
@@ -501,8 +507,6 @@ Style/RedundantCapitalW:
 Style/RedundantCondition:
   Enabled: false
 Style/RedundantConditional:
-  Enabled: false
-Style/RedundantException:
   Enabled: false
 Style/RedundantFetchBlock:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "rubocop", ">= 0.86.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.87.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 2.1"
   spec.add_development_dependency "rake", ">= 13.0"


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/releases/tag/v0.87.0

Some style cops since v0.87 are disabled.