### PR TITLE
Remove `AllCops.TargetRubyVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#107](https://github.com/sider/meowcop/pull/107): Follow up RuboCop v0.90
+- [#108](https://github.com/sider/meowcop/pull/108): Remove `AllCops.TargetRubyVersion`
 
 ## 2.13.0 (2020-08-06)
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ inherit_gem:
   meowcop:
     - config/rubocop.yml
 
-# Modify the version if you don't use MRI 2.6.
-AllCops:
-  TargetRubyVersion: 2.6
-
 # You can customize RuboCop settings.
 # For example.
 # Style/FrozenStringLiteralComment:

--- a/examples/.rubocop.yml
+++ b/examples/.rubocop.yml
@@ -3,10 +3,6 @@ inherit_gem:
   meowcop:
     - config/rubocop.yml
 
-# Modify the version if you don't use MRI 2.6.
-AllCops:
-  TargetRubyVersion: 2.6
-
 # You can customize RuboCop settings.
 # For example.
 # Style/FrozenStringLiteralComment:


### PR DESCRIPTION
This change aims to remove the `AllCops.TargetRubyVersion` setting
from a `.rubocop.yml` file generated by the `meowcop init` command.

Reasons:
- We need to update `TargetRubyVersion` in the future if a new version of Ruby will be released.
- Uses need to remove `TargetRubyVersion` manually if they uses their `.ruby-version` file.

For the reasons above, I don't think `TargetRubyVersion` is useful.

See also <https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version>