### PR TITLE
Follow up RuboCop v0.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#110](https://github.com/sider/meowcop/pull/110): Follow up RuboCop v0.93
+
 ## 2.14.0 (2020-09-08)
 
 - [#107](https://github.com/sider/meowcop/pull/107): Follow up RuboCop v0.90

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -296,6 +296,8 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/ClassCheck:
   Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
 Style/ClassMethods:
   Enabled: false
 Style/ClassMethodsDefinitions:

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -10,3 +10,6 @@ rules:
       -spec.add_dependency "rubocop", ">= 0.92.0", "< 1.0.0"
       +spec.add_dependency "rubocop", ">= 0.93.0", "< 1.0.0"
       ```
+    justification:
+      - When no need to update the gemspec.
+      - When the gemspec is already updated.

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,0 +1,12 @@
+rules:
+  - id: meowcop.gemspec
+    glob: config/rubocop.yml
+    message: |
+      Confirm whether to need updating also the `meowcop.gemspec` file.
+
+      For example, when adding new cops, it may be needed to update version requirements as follows:
+
+      ```diff
+      -spec.add_dependency "rubocop", ">= 0.92.0", "< 1.0.0"
+      +spec.add_dependency "rubocop", ">= 0.93.0", "< 1.0.0"
+      ```

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "rubocop", ">= 0.90.0", "< 1.0.0"
+  spec.add_dependency "rubocop", ">= 0.93.0", "< 1.0.0"
 
   spec.add_development_dependency "bundler", ">= 2.1"
   spec.add_development_dependency "rake", ">= 13.0"


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/releases/tag/v0.93.0

- Disabled the new `Style/ClassEqualityComparison` cop.