### PR TITLE
Loosen the max value of `Metrics/BlockNesting`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#117](https://github.com/sider/meowcop/pull/117): Loosen the max value of `Metrics/BlockNesting`
+
 ## 3.0.0 (2020-11-18)
 
 - [#113](https://github.com/sider/meowcop/pull/113): Simplify config file via RuboCop 1.0 (**breaking**)

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -52,7 +52,7 @@ Metrics/BlockLength:
     # Rails
     - 'config/routes.rb'
 Metrics/BlockNesting:
-  Max: 7
+  Max: 10
 Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -51,6 +51,8 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     # Rails
     - 'config/routes.rb'
+Metrics/BlockNesting:
+  Max: 7
 Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:


### PR DESCRIPTION
The `Max` default value of `Metrics/BlockNesting` is **3** but I think it's a bit too strict.
https://docs.rubocop.org/rubocop/1.4/cops_metrics.html#metricsblocknesting