### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, head]
+        ruby: [2.5, 2.6, 2.7, head]
     continue-on-error: ${{ matrix.ruby == 'head' }}
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#121](https://github.com/sider/meowcop/pull/121): Drop support for Ruby 2.4
+
 ## 3.0.1 (2020-12-02)
 
 - [#117](https://github.com/sider/meowcop/pull/117): Loosen the max value of `Metrics/BlockNesting`

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "rubocop", ">= 1.0.0", "< 2.0.0"
+  spec.add_runtime_dependency "rubocop", ">= 1.13.0", "< 2.0.0"
 
   spec.add_development_dependency "bundler", ">= 2.1"
   spec.add_development_dependency "rake", ">= 13.0"


### PR DESCRIPTION
The support of Ruby 2.4 has ended, and RuboCop also has dropped it.

See also:
- https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/
- https://github.com/rubocop/rubocop/releases/tag/v1.13.0