### PR TITLE
Replace `softprops/action-gh-release` with GitHub CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
         id: get_tag
-      - uses: softprops/action-gh-release@v1
-        with:
-          body: |
-            See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.get_tag.outputs.tag }}/CHANGELOG.md) for more details.
+      - run: gh release create '${{ steps.get_tag.outputs.tag }}' --notes 'See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.get_tag.outputs.tag }}/CHANGELOG.md) for more details.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub CLI (the `gh` command) is pre-installed, so the 3rd-party action is no longer needed.